### PR TITLE
Fix GCC 4.9 build errors

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -2618,7 +2618,11 @@ bool parse(Lexer & lexer,
            AstModulePtr & ast,
            SymbolTablePtr & symbols,
            ParserOptions options /*= ParserOptions()*/) {
-    State state{&lexer, {}, {}, {}, lexer.next(), {}, options, {}};
+    State state;
+    state.lexer = &lexer;
+    state.tok_cur = lexer.next();
+    state.options = options;
+
     if(file_input(state, ast)) {
         symbols = create_symbol_table(ast, state);
         return true;

--- a/src/pypa/parser/state.hh
+++ b/src/pypa/parser/state.hh
@@ -82,7 +82,7 @@ namespace {
     };
 
     inline void commit(State & s) {
-        s.popped = {};
+        s.popped = std::stack<TokenInfo>();
     }
 
     inline TokenInfo const & top(State & s) {


### PR DESCRIPTION
This fixes the build errors I'm getting with gcc 4.9.

```
pypa/parser/parser.cc:2621:66: error: converting to 'std::stack<pypa::TokenInfo>' from initializer list would use explicit constructor 'std::stack<_Tp, _Sequence>::stack(_Sequence&&) [with _Tp = pypa::TokenInfo; _Sequence = std::deque<pypa::TokenInfo>]'
```

Let me know if you prefer to have a constructor for `State` instead of this solution.

BTW: Thanks for writing the parser! :-) 
