### PR TITLE
Proper autotools support for make check rule

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,11 @@ AM_PROG_AR
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
 
+AC_ARG_WITH([cpython-src],
+            [AS_HELP_STRING([--with-cpython-src],
+                            [path to cpython sources, to feed the test suite])])
+AC_SUBST([CPYTHON_SRC], [$with_cpython_src])
+
 AC_CONFIG_FILES([
     Makefile
     src/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,6 +35,9 @@ parser_test_SOURCES=\
 	$(NULL)
 parser_test_LDADD=libpypa.la
 
+check-local:lexer-test parser-test $(srcdir)/run-tests.sh
+	CPYTHON_SRC=$(CPYTHON_SRC) $(srcdir)/run-tests.sh
+
 pypadir=$(includedir)/pypa
 pypa_HEADERS=\
 	pypa/filebuf.hh \

--- a/src/run-tests.sh
+++ b/src/run-tests.sh
@@ -6,11 +6,11 @@
 # Distributed under terms of the MIT license.
 #
 
-
+CPYTHON_SRC=${CPYTHON_SRC:-$HOME/devel/apps/cpython}
+test -d $CPYTHON_SRC/Python || { echo "CPYTHON_SRC not correctly set: $CPYTHON_SOURCE_DIR/Python not found" && exit 1; }
 mkdir -p results
-for file in `find ~/devel/apps/cpython/ -name "*.py"`;
+for file in `find $CPYTHON_SRC -name "*.py"`
 do
-    echo "Parsing $file";
-    ./parser-test $file &> ./results/`basename $file`.ast.out && rm -f ./results/`basename $file`.ast.out;
+    echo "Parsing $file"
+    ./parser-test $file &> ./results/`basename $file`.ast.out && rm -f ./results/`basename $file`.ast.out
 done
-


### PR DESCRIPTION
- use autoconf to spot the cpython source dir
- use automake to generate a check rule
- bypass hard coded path in test script

Still not perfect but seems better than current state.
