### PR TITLE
inital travis-ci.org support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: cpp
+compiler:
+  - clang
+
+install:
+  - sudo apt-get install cmake libgmp3-dev
+# libstdc++-4.8-dev
+  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -qq update
+  - sudo apt-get -qq install libstdc++-4.8-dev
+
+script:
+  - cmake . && make


### PR DESCRIPTION
Free testing from travis-ci.org
Looks like this https://travis-ci.org/dagar/libpypa-test/builds/40622515

You'll need to login to https://travis-ci.org with your github account and enable libpypa.
