### PR TITLE
add support for unicode literals

### DIFF
--- a/src/pypa/ast/ast.hh
+++ b/src/pypa/ast/ast.hh
@@ -156,8 +156,9 @@ PYPA_AST_MEMBERS3(DictComp, generators, key, value);
 
 PYPA_AST_STMT(DocString) {
     String doc;
+    bool unicode;
 };
-PYPA_AST_MEMBERS1(DocString, doc);
+PYPA_AST_MEMBERS2(DocString, doc, unicode);
 
 PYPA_AST_EXPR(EllipsisObject) {};
 PYPA_AST_MEMBERS0(EllipsisObject);
@@ -347,8 +348,9 @@ PYPA_AST_MEMBERS3(Slice, lower, step, upper);
 
 PYPA_AST_EXPR(Str) {
     String value;
+    bool unicode;
 };
-PYPA_AST_MEMBERS1(Str, value);
+PYPA_AST_MEMBERS2(Str, value, unicode);
 
 PYPA_AST_EXPR(Subscript) {
     AstExpr         value;

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -20,7 +20,7 @@
 
 namespace pypa {
 
-String make_string(String const & s);
+String make_string(String const & s, bool & unicode);
 
 template< typename Container >
 void flatten(AstStmt s, Container & target) {
@@ -826,8 +826,9 @@ bool atom(State & s, AstExpr & ast) {
         AstStrPtr str;
         location(s, create(str));
         ast = str;
+        str->unicode = s.future_features.unicode_literals;
         while(is(s, Token::String)) {
-            str->value.append(make_string(top(s).value));
+            str->value.append(make_string(top(s).value, str->unicode));
             expect(s, Token::String);
         }
     }
@@ -1615,6 +1616,7 @@ void make_docstring(State & s, AstSuitePtr & suite_) {
                 AstDocStringPtr ptr;
                 clone_location(txt, create(ptr));
                 ptr->doc = txt->value;
+                ptr->unicode = txt->unicode;
                 suite_->items[0] = ptr;
             }
         }


### PR DESCRIPTION
I'm trying to add unicode support to pypa (```u``` prefix, ```\u``` and ```\U``` and the ```unicode_literals``` feature)
This patch is currently in WIP state.

I'm particularly looking for comments on:
- how should I do proper error handling? Should I pass the ```State``` into ```make_string```?
- is the usage of iconv fine for converting the unicode character code to utf8, or should I use a different library/copy an implementation directly into pypa?
- how can I test the code? (I currently test it with pyston)