### PR TITLE
Add unicode support using a callback function

### DIFF
--- a/src/pypa/ast/ast.hh
+++ b/src/pypa/ast/ast.hh
@@ -156,8 +156,9 @@ PYPA_AST_MEMBERS3(DictComp, generators, key, value);
 
 PYPA_AST_STMT(DocString) {
     String doc;
+    bool unicode;
 };
-PYPA_AST_MEMBERS1(DocString, doc);
+PYPA_AST_MEMBERS2(DocString, doc, unicode);
 
 PYPA_AST_EXPR(EllipsisObject) {};
 PYPA_AST_MEMBERS0(EllipsisObject);
@@ -347,8 +348,9 @@ PYPA_AST_MEMBERS3(Slice, lower, step, upper);
 
 PYPA_AST_EXPR(Str) {
     String value;
+    bool unicode;
 };
-PYPA_AST_MEMBERS1(Str, value);
+PYPA_AST_MEMBERS2(Str, value, unicode);
 
 PYPA_AST_EXPR(Subscript) {
     AstExpr         value;

--- a/src/pypa/parser/make_string.cc
+++ b/src/pypa/parser/make_string.cc
@@ -27,39 +27,29 @@ inline bool islower(char c) {
     return (c >= 'a' && c <= 'z');
 }
 
-String make_string(String const & input) {
+String make_string(String const & input, bool & unicode, bool & raw) {
     String result;
     size_t first_quote  = input.find_first_of("\"'");
     assert(first_quote != String::npos);
     char quote = input[first_quote];
     size_t string_start = input.find_first_not_of(quote, first_quote);
-    if(string_start == String::npos) {
-        // Empty string
-        return result;
-    }
-    assert((string_start - first_quote) < input.size());
-    size_t string_end =  input.size() - (string_start - first_quote);
-    assert(string_end != String::npos && string_start <= string_end);
 
-    char const * s = input.c_str() + string_start;
-    char const * end = input.c_str() + string_end;
     char const * qst = input.c_str() + first_quote;
     char const * tmp = input.c_str();
 
-    // bool unicode = false;
-    bool raw = false;
     // bool bytes = false;
-
+    raw = false;
     while(tmp != qst) {
         switch(*tmp) {
         case 'u': case 'U':
-            // unicode = true;
+            unicode = true;
             break;
         case 'r': case 'R':
             raw = true;
             break;
         case 'b': case 'B':
             // bytes = true;
+            unicode = false;
             break;
         default:
             assert("Unknown character prefix" && false);
@@ -69,12 +59,23 @@ String make_string(String const & input) {
     }
 
 
+    if(string_start == String::npos) {
+        // Empty string
+        return result;
+    }
+
+    assert((string_start - first_quote) < input.size());
+    size_t string_end =  input.size() - (string_start - first_quote);
+    assert(string_end != String::npos && string_start <= string_end);
+
+    char const * s = input.c_str() + string_start;
+    char const * end = input.c_str() + string_end;
 
     std::back_insert_iterator<String> p((result));
 
     while(s < end) {
         char c = *s;
-        if(raw) {
+        if(raw || unicode) {
             *p++ = *s++;
         }
         else { // !raw

--- a/src/pypa/parser/parser.hh
+++ b/src/pypa/parser/parser.hh
@@ -17,6 +17,7 @@
 #include <pypa/ast/ast.hh>
 #include <pypa/lexer/lexer.hh>
 #include <pypa/parser/symbol_table.hh>
+#include <pypa/types.hh>
 #include <functional>
 
 namespace pypa {
@@ -41,6 +42,7 @@ struct ParserOptions {
     bool handle_future_errors; // Handles unknown __future__ features
                                // by reporting an error
     std::function<void(pypa::Error)> error_handler;
+    std::function<pypa::String(pypa::String, bool raw_prefix, bool & error)> unicode_escape_handler;
 };
 
 bool parse(Lexer & lexer,


### PR DESCRIPTION
This adds the unicode support using a callback function.
The corresponding pyston change can be found here: https://github.com/undingen/pyston/tree/pypa_unicode

I find this solution much better than reimplementing the unicode escape sequence handling inside pypa.
I hope this is enough to make pypa still useful outside of pyston. 