### PR TITLE
Don't raise an IndentationError if a newline is missing at the end of the file

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -1661,7 +1661,7 @@ bool suite(State & s, AstStmt & ast) {
                     stmt_.reset();
                 }
                 make_docstring(s, suite_);
-                if(!expect(s, Token::Dedent)) {
+                if(!expect(s, Token::Dedent) && !is(s, Token::End)) {
                     indentation_error(s, ast);
                     return false;
                 }

--- a/test/tests/no_newline.py
+++ b/test/tests/no_newline.py
@@ -1,0 +1,11 @@
+import os
+import os.path
+
+
+def cs_path_exists(fspath):
+    if not os.path.exists(fspath): 
+        return False
+    # make absolute so we always have a directory
+    abspath = os.path.abspath(fspath)
+    directory, filename = os.path.split(abspath)
+    return filename in os.listdir(directory)


### PR DESCRIPTION
I think this should fix #13.