### PR TITLE
Don't raise an IndentationError if a newline is missing at the end of a 'from import' line

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -2419,7 +2419,7 @@ bool import_as_names(State & s, AstExpr & ast) {
             break;
         }
     }
-    if(!is(s, TokenKind::NewLine) && !is(s, TokenKind::SemiColon) && !is(s, TokenKind::RightParen)) {
+    if(!is(s, TokenKind::NewLine) && !is(s, TokenKind::SemiColon) && !is(s, TokenKind::RightParen) && !is(s, Token::End)) {
         syntax_error(s, ast, "Unexpected token");
         return false;
     }

--- a/test/tests/no_newline2.py
+++ b/test/tests/no_newline2.py
@@ -1,0 +1,1 @@
+from .core import where


### PR DESCRIPTION
I'm wondering if this will occur in more places and needs a more generic fix?