### PR TITLE
Throw a syntax error for a top-level issue

### DIFF
--- a/src/pypa/lexer/lexer.cc
+++ b/src/pypa/lexer/lexer.cc
@@ -219,7 +219,11 @@ namespace pypa {
                         if(cur == '\r') continue;
                     }
                     if (cur == '\\') {
-                        tok.value.push_back(next_char());
+                        char c = next_char();
+                        if (c == '\r')
+                            tok.value.push_back(next_char());
+                        else
+                            tok.value.push_back(c);
                     }
                 }
             };

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -2662,6 +2662,7 @@ bool file_input(State & s, AstModulePtr & ast) {
             }
         }
         else {
+            syntax_error(s, ast, "invalid syntax");
             return false;
         }
     }


### PR DESCRIPTION
I'm investigating why Pyston crashes when we try to parse something like `]` (with that as the entire file).  I tracked it down to hitting this branch, and this seems like the way syntax errors are handled elsewhere?