### PR TITLE
Allow trailing commas in set literals

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -2053,7 +2053,6 @@ bool dictorsetmaker(State & s, AstExpr & ast) {
                 ptr->elements.push_back(first);
                 while(expect(s, TokenKind::Comma)) {
                     if(!test(s, first)) {
-                        syntax_error(s, ast, "Expected expression after `,`");
                         break;
                     }
                     ptr->elements.push_back(first);


### PR DESCRIPTION
Currently pypa doesn't support set literals with trailing commas, such as `{1,}`.  My understanding of pypa is still pretty hazy, but it looks like the set parsing code has this extra syntax_error() call, but the dict and list parsing code do not.