### PR TITLE
Wrong locaton for syntax error

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -77,7 +77,7 @@ void add_symbol_error(State & s, char const * message, int line, int column, int
 
 void syntax_error_dbg(State & s, AstPtr ast, char const * message, int line = -1, char const * file = 0, char const * function = 0) {
     TokenInfo cur = top(s);
-    if(ast && cur.line > ast->line) {
+    if(ast && cur.line < ast->line) {
         cur.line    = ast->line;
         cur.column  = ast->column;
     }


### PR DESCRIPTION
Syntax errors inside function/modules get reported at the wrong location. Most often at the first line of the function where the syntax error happens. For example take a look at ```file_input()``` it passes the module as AST node to the error function.
Looks like this if inside ```syntax_error_dbg()``` is the reason, I'm wondering if the condition is just swapped or if the issue has to be handled in a different place?
Sorry for using a pull request for discussion / asking a question...