### PR TITLE
Add support for specifying the file encoding using '# coding'.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,7 @@ check-local:lexer-test parser-test $(srcdir)/run-tests.sh
 pypadir=$(includedir)/pypa
 pypa_HEADERS=\
 	pypa/filebuf.hh \
+	pypa/reader.hh \
 	pypa/types.hh \
 	$(NULL)
 

--- a/src/pypa/filebuf.cc
+++ b/src/pypa/filebuf.cc
@@ -107,6 +107,25 @@ namespace pypa {
         length_ = n <= 0 ? 0 : unsigned(n);
         return length_ != 0;
     }
+
+
+    FileBufReader::FileBufReader(const std::string & file_name)
+    : file_name_(file_name), buf_(file_name.c_str())
+    {
+    }
+
+    std::string FileBufReader::get_line() {
+        std::string line;
+        char c;
+        do {
+            c = buf_.next();
+            if(buf_.eof())
+                break;
+            line.push_back(c);
+        } while(c != '\n' && c != '\x0c');
+        return line;
+    }
+
 }
 
 

--- a/src/pypa/filebuf.hh
+++ b/src/pypa/filebuf.hh
@@ -14,7 +14,9 @@
 #ifndef GUARD_PYPA_FILEBUF_HH_INCLUDED
 #define GUARD_PYPA_FILEBUF_HH_INCLUDED
 
+#include <pypa/reader.hh>
 #include <cstddef>
+#include <string>
 
 namespace pypa {
 
@@ -45,6 +47,23 @@ public:
     bool utf8() const;
 private:
     bool fill_buffer();
+};
+
+
+class FileBufReader : public Reader {
+public:
+    FileBufReader(const std::string & file_name);
+    ~FileBufReader() override {}
+
+    bool set_encoding(const std::string & coding) override { return true; }
+    std::string get_line() override;
+    unsigned get_line_number() const override { return buf_.line(); }
+    std::string get_filename() const override { return file_name_; }
+    bool eof() const override { return buf_.eof(); }
+
+private:
+    std::string file_name_;
+    FileBuf buf_;
 };
 
 }

--- a/src/pypa/lexer/lexer.hh
+++ b/src/pypa/lexer/lexer.hh
@@ -1,4 +1,4 @@
-// Copyright 2014 Vinzenz Feenstra
+﻿// Copyright 2014 Vinzenz Feenstra
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
 #ifndef GUARD_PYPA_TOKENIZER_LEXER_HH_INCLUDED
 #define GUARD_PYPA_TOKENIZER_LEXER_HH_INCLUDED
 
-#include <pypa/filebuf.hh>
+#include <pypa/reader.hh>
 #include <pypa/lexer/tokendef.hh>
 #include <string>
 #include <deque>
 #include <list>
 #include <vector>
 #include <stdint.h>
+#include <memory>
 
 namespace pypa {
 
@@ -49,9 +50,9 @@ class Lexer {
         AltTabSize = 1,
     };
 
-    pypa::FileBuf file_;
-    std::string input_path_;
-
+    std::unique_ptr<Reader> reader_;
+    bool read_encoding_;
+    std::string encoding_;
     uint32_t column_;
     int level_;
     int indent_;
@@ -62,12 +63,18 @@ class Lexer {
     std::list<LexerInfo> info_;
     char first_indet_char;
     std::deque<TokenInfo> token_buffer_;
+
 public:
     Lexer(char const * file_path);
+    Lexer(std::unique_ptr<Reader> reader);
+
     ~Lexer();
 
     std::string get_name() const;
     std::string get_line(int idx);
+    std::string get_encoding() const {
+        return encoding_;
+    }
 
     std::list<LexerInfo> const & info();
 
@@ -76,7 +83,8 @@ public:
 private:
     char skip();
     char skip_comment();
-    unsigned line() const { return file_.line(); }
+    char skip_comment_check_coding();
+    unsigned line() const { return reader_->get_line_number(); }
     char next_char();
     void put_char(char c);
     TokenInfo get_string(TokenInfo & tok, char first, char prefix=0);

--- a/src/pypa/lexer/tokens.hh
+++ b/src/pypa/lexer/tokens.hh
@@ -28,6 +28,7 @@ namespace pypa {
         DedentationError,
         LineContinuationError,
         UnterminatedStringError,
+        EncodingError,
 
         Comment,
         BackQuote,

--- a/src/pypa/parser/make_string.cc
+++ b/src/pypa/parser/make_string.cc
@@ -27,7 +27,7 @@ inline bool islower(char c) {
     return (c >= 'a' && c <= 'z');
 }
 
-String make_string(String const & input, bool & unicode, bool & raw) {
+String make_string(String const & input, bool & unicode, bool & raw, bool ignore_escaping) {
     String result;
     size_t first_quote  = input.find_first_of("\"'");
     assert(first_quote != String::npos);
@@ -75,7 +75,7 @@ String make_string(String const & input, bool & unicode, bool & raw) {
 
     while(s < end) {
         char c = *s;
-        if(raw || unicode) {
+        if(raw || unicode || ignore_escaping) {
             *p++ = *s++;
         }
         else { // !raw
@@ -147,6 +147,5 @@ String make_string(String const & input, bool & unicode, bool & raw) {
     }
     return result;
 }
-
 
 }

--- a/src/pypa/parser/parser.hh
+++ b/src/pypa/parser/parser.hh
@@ -42,7 +42,7 @@ struct ParserOptions {
     bool handle_future_errors; // Handles unknown __future__ features
                                // by reporting an error
     std::function<void(pypa::Error)> error_handler;
-    std::function<pypa::String(pypa::String, bool raw_prefix, bool & error)> unicode_escape_handler;
+    std::function<pypa::String(const pypa::String & value, const pypa::String & encoding, bool unicode, bool raw_prefix, bool & error)> escape_handler;
 };
 
 bool parse(Lexer & lexer,

--- a/src/pypa/reader.hh
+++ b/src/pypa/reader.hh
@@ -1,0 +1,36 @@
+// Copyright 2014 Vinzenz Feenstra
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GUARD_PYPA_READER_HH_INCLUDED
+#define GUARD_PYPA_READER_HH_INCLUDED
+
+#include <cstddef>
+#include <string>
+
+namespace pypa {
+
+class Reader {
+public:
+    Reader() {}
+    virtual ~Reader() {}
+
+    virtual bool set_encoding(const std::string & coding) = 0;
+    virtual std::string get_line() = 0;
+    virtual unsigned get_line_number() const = 0;
+    virtual std::string get_filename() const = 0;
+    virtual bool eof() const = 0;
+};
+
+}
+
+#endif //GUARD_PYPA_READER_HH_INCLUDED


### PR DESCRIPTION
Sadly the actual decoding can't be done inside pypa because one can register custom encodings (e.g. have a look at https://github.com/dropbox/pyxl).

The corresponding change for pyston is this one: https://github.com/dropbox/pyston/pull/476
I expect that there are still bugs hiding but at least the pyston tests pass and pyxl helloworld works.
