### PR TITLE
Support newline between decorator and function

### DIFF
--- a/src/pypa/lexer/lexer.cc
+++ b/src/pypa/lexer/lexer.cc
@@ -618,8 +618,8 @@ namespace pypa {
         }
         put_char(c);
         if(continuation || level_ != 0 || c == '#' || c == '\n' || c == '\r' || c == '\x0c') {
-            if(c == '#') {
-                // If this line is a commented line, don't emit NewLine
+            if(c == '#' || c == '\n') {
+                // If this line is a commented line or an empty line, don't emit NewLine
                 if(!token_buffer_.empty() && token_buffer_.back().ident.id() == Token::NewLine) {
                     token_buffer_.pop_back();
                 }

--- a/test/tests/decorator_whitespace.py
+++ b/test/tests/decorator_whitespace.py
@@ -1,0 +1,9 @@
+# fail-if: '-x' not in EXTRA_JIT_ARGS
+
+def dec(f):
+    return f
+
+@dec
+
+def f():
+    pass


### PR DESCRIPTION
I had this first fixed inside the decorator parsing code by skipping additional newline tokens.
But then I figured out that it probably needs to be handled during lexing because the python grammar just contains a single NEWLINE.
```
decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE
decorators: decorator+
decorated: decorators (classdef | funcdef)
```
I find the lexer control flow quite difficult to understand so please have a careful look if this change is correct. With the change we should only emit a single NEWLINE token. 
