### PR TITLE
Fix tuple assignment error

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -1784,6 +1784,7 @@ bool expr_stmt(State & s, AstStmt & ast) {
                     case AstType::Name:
                     case AstType::Attribute:
                     case AstType::Subscript:
+                    case AstType::Tuple:
                         break;
                     default:
                         syntax_error(s, target, "Illegal expression for assignment");


### PR DESCRIPTION
I think a small error slipped in with the last commits.
This should fix it. Sorry I dont't have much time right now so I didn't verify it in detail.
But without this fails:
```
    head, tail = path.split(name)
SyntaxError: Illegal expression for assignment
```