### PR TITLE
Fix -(1+6j) issue.

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -1158,12 +1158,12 @@ bool factor(State & s, AstExpr & ast) {
                             p->real->str = '-' + p->real->str;
                             break;
                         }
-                        ast = p;
                     }
-                    else {
-                        p->imag = '-' + p->imag;
-                        ast = p;
+                    if (p->imag[0] == '+') {
+                        p->imag.erase(0, 1);
                     }
+                    p->imag = '-' + p->imag;
+                    ast = p;
                 }
             }
             return guard.commit();


### PR DESCRIPTION
Something like `-(1+6j)` will return `-1+6j`.

`p->imag` always exist in this situation, and check the first char whether is `+`, if so, remove it.

Feel free to choose other solution. :) 