### PR TITLE
Support passing initial future flags

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -2766,6 +2766,7 @@ bool parse(Lexer & lexer,
     state.lexer = &lexer;
     state.tok_cur = lexer.next();
     state.options = options;
+    state.future_features = options.initial_future_features;
 
     if(is(state, Token::EncodingError)) {
         syntax_error(state, AstPtr(), state.tok_cur.value.c_str());

--- a/src/pypa/parser/parser.hh
+++ b/src/pypa/parser/parser.hh
@@ -43,6 +43,8 @@ struct ParserOptions {
     bool printdbgerrors;       // Prints internal debug information
     bool handle_future_errors; // Handles unknown __future__ features
                                // by reporting an error
+    FutureFeatures initial_future_features;
+
     std::function<void(pypa::Error)> error_handler;
     std::function<pypa::String(pypa::String const & value,
                                pypa::String const & encoding,


### PR DESCRIPTION
The strings for eval and exec statements are supposed to inherit
the future flags of the parent (well, usually).  Most flags
are fine being handled post-parsing, but some (print_function)
affect the behavior of the parser so need to be passed.