### PR TITLE
make g++7 happy

### DIFF
--- a/src/pypa/lexer/lexer.cc
+++ b/src/pypa/lexer/lexer.cc
@@ -339,6 +339,7 @@ namespace pypa {
                 tok.ident = {Token::NumberFloat, TokenKind::Number, TokenClass::Literal};
                 break;
             }
+            // fallthrough
         case 'e': case 'E':
             tok.ident = {Token::NumberFloat, TokenKind::Number, TokenClass::Literal};
             tok.value.push_back(first);

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -1794,6 +1794,7 @@ bool expr_stmt(State & s, AstStmt & ast) {
                         if(!std::static_pointer_cast<AstTuple>(target)->elements.empty()) {
                             break; // Break on non empty tuples only
                         }
+                        // fallthrough
                     default:
                         syntax_error(s, target, "Illegal expression for assignment");
                         return false;

--- a/src/pypa/parser/symbol_table.hh
+++ b/src/pypa/parser/symbol_table.hh
@@ -17,6 +17,7 @@
 #include <list>
 #include <memory>
 #include <stack>
+#include <functional>
 #include <unordered_set>
 #include <unordered_map>
 


### PR DESCRIPTION
1. add explicit fallthrough comment. see: <https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/>
2. add missing #include <functional>

```
libtool: compile:  g++ "-DPACKAGE_NAME=\"A python 2 parser\"" -DPACKAGE_TARNAME=\"pypa\" -DPACKAGE_VERSION=\"0.1\" "-DPACKAGE_STRING=\"A python 2 parser 0.1\"" -DPACKAGE_BUGREPORT=\"evilissimo@gmail.com\" -DPACKAGE_URL=\"http://github.com/vinzenz/pypa\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I. -DIEEE_8087 -g -O2 -Werror -W -Wall -pedantic -Wno-unused-parameter -Wno-unused-local-typedefs -MT pypa/lexer/lexer.lo -MD -MP -MF pypa/lexer/.deps/lexer.Tpo -c pypa/lexer/lexer.cc  -fPIC -DPIC -o pypa/lexer/.libs/lexer.o
pypa/lexer/lexer.cc: In member function ‘pypa::TokenInfo pypa::Lexer::get_number_float(pypa::TokenInfo&, char)’:
pypa/lexer/lexer.cc:337:18: error: this statement may fall through [-Werror=implicit-fallthrough=]
             else if (first != 'e' && first != 'E') {
                  ^~
pypa/lexer/lexer.cc:342:9: note: here
         case 'e': case 'E':
         ^~~~



libtool: compile:  g++ "-DPACKAGE_NAME=\"A python 2 parser\"" -DPACKAGE_TARNAME=\"pypa\" -DPACKAGE_VERSION=\"0.1\" "-DPACKAGE_STRING=\"A python 2 parser 0.1\"" -DPACKAGE_BUGREPORT=\"evilissimo@gmail.com\" -DPACKAGE_URL=\"http://github.com/vinzenz/pypa\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I. -DIEEE_8087 -g -O2 -Werror -W -Wall -pedantic -Wno-unused-parameter -Wno-unused-local-typedefs -MT pypa/parser/parser.lo -MD -MP -MF pypa/parser/.deps/parser.Tpo -c pypa/parser/parser.cc  -fPIC -DPIC -o pypa/parser/.libs/parser.o
pypa/parser/parser.cc: In lambda function:
pypa/parser/parser.cc:1794:25: error: this statement may fall through [-Werror=implicit-fallthrough=]
                         if(!std::static_pointer_cast<AstTuple>(target)->elements.empty()) {
                         ^~
pypa/parser/parser.cc:1797:21: note: here
                     default:
                     ^~~~~~~



libtool: compile:  g++ "-DPACKAGE_NAME=\"A python 2 parser\"" -DPACKAGE_TARNAME=\"pypa\" -DPACKAGE_VERSION=\"0.1\" "-DPACKAGE_STRING=\"A python 2 parser 0.1\"" -DPACKAGE_BUGREPORT=\"evilissimo@gmail.com\" -DPACKAGE_URL=\"http://github.com/vinzenz/pypa\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I. -DIEEE_8087 -g -O2 -Werror -W -Wall -pedantic -Wno-unused-parameter -Wno-unused-local-typedefs -MT pypa/parser/symbol_table.lo -MD -MP -MF pypa/parser/.deps/symbol_table.Tpo -c pypa/parser/symbol_table.cc  -fPIC -DPIC -o pypa/parser/.libs/symbol_table.o
In file included from pypa/parser/symbol_table.cc:16:0:
./pypa/parser/symbol_table.hh:101:14: error: ‘function’ in namespace ‘std’ does not name a template type
 typedef std::function<void(pypa::Error)> SymbolErrorReportFun;


```