### PR TITLE
More generic reader interface

### DIFF
--- a/src/pypa/filebuf.cc
+++ b/src/pypa/filebuf.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <pypa/filebuf.hh>
+#include <fstream>
 
 #if defined(WIN32)
 #include <windows.h>
@@ -114,7 +115,19 @@ namespace pypa {
     {
     }
 
-    std::string FileBufReader::get_line() {
+    std::string FileBufReader::get_line(size_t idx) {
+        idx = idx ? idx - 1 : idx;
+        std::ifstream ifs(get_filename());
+        std::string line;
+        size_t lineno = 1;
+        while(std::getline(ifs, line) && lineno != idx) {
+            ++lineno;
+        }
+        return line;
+
+    }
+
+    std::string FileBufReader::next_line() {
         std::string line;
         char c;
         do {

--- a/src/pypa/filebuf.hh
+++ b/src/pypa/filebuf.hh
@@ -57,7 +57,8 @@ public:
     ~FileBufReader() override {}
 
     bool set_encoding(const std::string & coding) override { return true; }
-    std::string get_line() override;
+    std::string next_line() override;
+    std::string get_line(size_t idx) override;
     unsigned get_line_number() const override { return buf_.line(); }
     std::string get_filename() const override { return file_name_; }
     bool eof() const override { return buf_.eof(); }

--- a/src/pypa/lexer/lexer.cc
+++ b/src/pypa/lexer/lexer.cc
@@ -72,14 +72,7 @@ namespace pypa {
     }
 
     std::string Lexer::get_line(int idx) {
-        idx = idx ? idx - 1 : idx;
-        std::ifstream ifs(reader_->get_filename());
-        std::string line;
-        int lineno = 1;
-        while(std::getline(ifs, line) && lineno != idx) {
-            ++lineno;
-        }
-        return line;
+        return reader_->get_line(idx);
     }
 
     Lexer::Lexer(char const * file_path)
@@ -414,7 +407,7 @@ namespace pypa {
     char Lexer::next_char() {
         column_++;
         if (lex_buffer_.empty()) {
-            std::string line = reader_->get_line();
+            std::string line = reader_->next_line();
             if (line.empty() && reader_->eof())
                 return -1;
             lex_buffer_.insert(lex_buffer_.end(), line.begin(), line.end());

--- a/src/pypa/reader.hh
+++ b/src/pypa/reader.hh
@@ -25,7 +25,8 @@ public:
     virtual ~Reader() {}
 
     virtual bool set_encoding(const std::string & coding) = 0;
-    virtual std::string get_line() = 0;
+    virtual std::string next_line() = 0;
+    virtual std::string get_line(size_t idx) = 0;
     virtual unsigned get_line_number() const = 0;
     virtual std::string get_filename() const = 0;
     virtual bool eof() const = 0;


### PR DESCRIPTION
Move the get line function into the reader interface, so that readers that don't read from the disk work correctly.