### PR TITLE
Visual Studio 2017 support (Windows)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,16 @@ include(CheckCXXCompilerFlag)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${libpypa_SOURCE_DIR}/modules/")
 find_package(GMP REQUIRED)
+include_directories(${GMP_INCLUDES})
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -W -Wall -Werror -pedantic -Wno-unused-parameter -Wno-unused-const-variable")
+if (UNIX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -W -Wall -Werror -pedantic -Wno-unused-parameter -Wno-unused-const-variable")
 
-check_cxx_compiler_flag(-Wno-unused-local-typedefs CXX_NO_UNUSED_LOCAL_TYPEDEFS)
-if(CXX_NO_UNUSED_LOCAL_TYPEDEFS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+    check_cxx_compiler_flag(-Wno-unused-local-typedefs CXX_NO_UNUSED_LOCAL_TYPEDEFS)
+    if(CXX_NO_UNUSED_LOCAL_TYPEDEFS)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-local-typedefs")
+    endif()
 endif()
 
 set(CLANG_FLAGS "-Qunused-arguments -fcolor-diagnostics" CACHE STRING "Clang specific C and CXX flags")
@@ -29,12 +32,12 @@ add_library(pypa pypa/ast/ast.cc
 # lexer_test
 add_executable(lexer-test EXCLUDE_FROM_ALL pypa/parser/test.cc)
 add_dependencies(lexer-test pypa)
-target_link_libraries(lexer-test pypa gmp double-conversion)
+target_link_libraries(lexer-test pypa ${GMP_LIBRARIES} double-conversion)
 
 # parser_test
 add_executable(parser-test EXCLUDE_FROM_ALL pypa/parser/test.cc)
 add_dependencies(parser-test pypa)
-target_link_libraries(parser-test pypa gmp double-conversion)
+target_link_libraries(parser-test pypa ${GMP_LIBRARIES} double-conversion)
 
 # install
 install(TARGETS pypa ARCHIVE DESTINATION lib)

--- a/src/pypa/ast/ast.hh
+++ b/src/pypa/ast/ast.hh
@@ -279,7 +279,7 @@ PYPA_AST_EXPR(Number) {
     union {
         double  floating;
         int64_t integer;
-        char    data[sizeof(floating) > sizeof(integer) ? sizeof(floating) : sizeof(integer)];
+        char    data[sizeof(double) > sizeof(int64_t) ? sizeof(double) : sizeof(int64_t)];
     };
     String str;
 };

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -99,8 +99,13 @@ void indentation_error_dbg(State & s, AstPtr ast, int line = -1, char const * fi
     report_error(s);
 }
 
+#ifdef _WIN32
+#define syntax_error(s, AST_ITEM, msg) syntax_error_dbg(s, error_transform(AST_ITEM), msg, __LINE__, __FILE__, __func__)
+#define indentation_error(s, AST_ITEM) indentation_error_dbg(s, error_transform(AST_ITEM), __LINE__, __FILE__, __func__)
+#else
 #define syntax_error(s, AST_ITEM, msg) syntax_error_dbg(s, error_transform(AST_ITEM), msg, __LINE__, __FILE__, __PRETTY_FUNCTION__)
 #define indentation_error(s, AST_ITEM) indentation_error_dbg(s, error_transform(AST_ITEM), __LINE__, __FILE__, __PRETTY_FUNCTION__)
+#endif
 
 bool number_from_base(int64_t base, State & s, AstNumberPtr & ast) {
     String const & value = top(s).value;

--- a/src/pypa/parser/symbol_table_visitor.hh
+++ b/src/pypa/parser/symbol_table_visitor.hh
@@ -19,8 +19,13 @@
 
 namespace pypa {
 
+#ifdef _WIN32
+#define PYPA_ADD_SYMBOL_ERR(MSG, AST) add_error(MSG, AST, __LINE__, __FILE__, __func__)
+#define PYPA_ADD_SYMBOL_WARN(MSG, AST) add_warn(MSG, AST, __LINE__, __FILE__, __func__)
+#else
 #define PYPA_ADD_SYMBOL_ERR(MSG, AST) add_error(MSG, AST, __LINE__, __FILE__, __PRETTY_FUNCTION__)
 #define PYPA_ADD_SYMBOL_WARN(MSG, AST) add_warn(MSG, AST, __LINE__, __FILE__, __PRETTY_FUNCTION__)
+#endif
 
     struct symbol_table_visitor {
         SymbolTablePtr table;


### PR DESCRIPTION
With these simple changes the project compiles and runs on Windows using Visual Studio 2017.

I got the GMP library for windows from here:
https://cs.nyu.edu/~exact/core/gmp/index.html
